### PR TITLE
Update install.js with some benefits

### DIFF
--- a/install.js
+++ b/install.js
@@ -42,28 +42,28 @@ module.exports = {
     {
       method: "shell.run",
       params: {
-        venv: "../../../env",                // Edit this to customize the venv folder path
+        venv: "env",                // Edit this to customize the venv folder path
         env: {
           USE_NINJA: 0,
           DISTUTILS_USE_SDK: 1
         },
-        path: "app/hy3dgen/texgen/custom_rasterizer",                // Edit this to customize the path to start the shell from
+        path: "app",                // Edit this to customize the path to start the shell from
         message: [
-          "python setup.py install"
+          "uv pip install ./hy3dgen/texgen/custom_rasterizer --no-build-isolation"
         ]
       }
     },
     {
       method: "shell.run",
       params: {
-        venv: "../../../env",                // Edit this to customize the venv folder path
+        venv: "env",                // Edit this to customize the venv folder path
         env: {
           USE_NINJA: 0,
           DISTUTILS_USE_SDK: 1
         },
-        path: "app/hy3dgen/texgen/differentiable_renderer",                // Edit this to customize the path to start the shell from
+        path: "app",                // Edit this to customize the path to start the shell from
         message: [
-          "python setup.py install"
+          "uv pip install ./hy3dgen/texgen/differentiable_renderer --no-build-isolation"
         ]
       }
     },


### PR DESCRIPTION
This is just a cleanup of the code so that we are using the standard `env` instead of `../../../env`, which also focuses on an alternative to `python setup.py install`, by using `uv`. 

This method makes it a lot more obvious to see errors as `uv` will just say `Building...` whilst it builds the package in the background and colour-codes the information so when and if there is an error or it fails to build, it is more obvious to the user. 

This method will not only make it a much cleaner install, but it will also make it a lot faster too.

Please review this code before committing to peer-check for potential errors. One I am aware of is when building packages, sometimes they build in isolation from the rest of the project's dependencies, hence `--no-build-isolation`